### PR TITLE
Add publishing pipeline

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,42 @@
+name: "Build and Publish"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    environment: release
+    permissions:
+      id-token: write 
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
+        # to supply options, put them in 'env', like:
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_SKIP: "*_i686 *-musllinux_*"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lie_learn-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./dist/*.whl
+
+      - name: Publish package
+        if: matrix.os == 'ubuntu-latest'
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,14 @@ requires = [
   'setuptools',
   'setuptools-scm',
   'cython',
-  'numpy ; python_version>="3.0"',
+  'numpy<2 ; python_version>="3.0"',
   'numpy<1.17 ; python_version<"3.0"',
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "lie_learn"
-version = "0.0.1.post1"
+version = "0.0.2"
 description = "A python package that knows how to do various tricky computations related to Lie groups and manifolds (mainly the sphere S2 and rotation group SO3)."
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -19,15 +19,16 @@ requires-python = ">2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 classifiers = [
   "Programming Language :: Python :: 2.7",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
 dependencies = [
   'requests',
-  'numpy ; python_version>="3.0"',
+  'numpy<2 ; python_version>="3.0"',
   'scipy ; python_version>="3.0"',
   'numpy<1.17 ; python_version<"3.0"',
   'scipy<1.3 ; python_version<"3.0"',


### PR DESCRIPTION
This pull request addresses #27 by implementing a publishing pipeline in `.github/workflow/publish.yaml`. 
The action is triggered every time a new version of `lie_learn` gets published and it automatically updates the entry on [pypi](https://pypi.org/project/lie-learn/). 
In this way, downstream libraries (like [escnn](https://github.com/QUVA-Lab/escnn)) can use lie_learn much more easily.

To fully close #27 it is required to:
1) enable [trusted publishing](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) 
2) either publish a new release of `lie_learn` or [manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) trigger `publish.yaml` via: 
Actions->'Build and Publish'->Run Workflow

----
Due to the [end of life](https://endoflife.date/python) the current process only supports python>=3.9, but it is possible to include older versions to this workflow if needed.

Finally, notice that there are some issues with the [recent release of Numpy 2.0.0](https://numpy.org/devdocs/release/2.0.0-notes.html) (also discussed in #30), so we have enforced `numpy<2` in the dependency.



